### PR TITLE
fix and test data line criteria

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -50,7 +50,7 @@ const _getSheet = (keyword, spreadSheet) =>
  */
 const _getSheetData = (sheetModel, sheet) => {
   const headerLine = _getHeaderLine(sheet);
-  const isDataLine = line => line.length > 1 && !!line[0] && !!line[1]; 
+  const isDataLine = line => line.length > 1 && !!line[1];
   return sheet
     .filter((line, index) => index >= headerLine && line.length >= sheetModel.length && isDataLine(line))
     .map(line =>

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -150,6 +150,34 @@ describe('paser _getSheetData', () => {
       {campo1: 'dados31', campo2: 'dados32'}
     ]);
   });
+
+  it('should remove lines that are not data', () => {
+    const sheetMock = [
+      ['asdf', 'asdf'], 
+      ['fsda', 'fasd'], 
+      ['cpf', 'nome'], //header
+      [0, 'dados12'], 
+      ['dados21', 'dados22'], 
+      ['dados31', 'dados32'], 
+      [0, 'dados42'], 
+      ['dados51', 'dados52'], 
+      [] 
+    ];
+    const sheetModel = [
+      {fieldName: 'campo1'},
+      {fieldName: 'campo2'},
+    ];
+
+    const data = parser._getSheetData(sheetModel, sheetMock);
+    
+    expect(data).toEqual([
+      {campo1: 0, campo2: 'dados12'},
+      {campo1: 'dados21', campo2: 'dados22'},
+      {campo1: 'dados31', campo2: 'dados32'},
+      {campo1: 0, campo2: 'dados42'},
+      {campo1: 'dados51', campo2: 'dados52'}
+    ]);
+  });
 });
 
 describe('parser _getContrachequeData', () => {


### PR DESCRIPTION
Algumas planilhas possuem o campo CPF preenchido com o valor `0`, que é avalia como falsy. Assim, nenhuma linha da planilha era reconhecida como dado.

Modifiquei a verificação para olhar apenas para a coluna `Nome`, já que ela de fato nunca pode assumir nenhum valor falsy.

Passei pelo menos umas 3h hoje pra saber que era isso que estava acontecendo :sweat_smile: 