### PR TITLE
remove dados cadastrais sheet check

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -125,7 +125,7 @@ const _getOrgao = contrachequeSheet => {
   let orgao = "";
   const orgaoLabel = "Órgão";
   const found = contrachequeSheet.some(line => {
-    if (line[0] && line[0].trim() === orgaoLabel) {
+    if (line[0] && isNaN(line[0]) && line[0].trim() === orgaoLabel) {
       orgao = line.reduce((acc, el) => {
         return !!el ? el : acc;
       }, "");
@@ -332,11 +332,7 @@ const _getDadosCadastraisData = spreadSheet => {
     { fieldName: 'orgao_de_origem', type: 'text' },
     { fieldName: 'cargo_de_origem', type: 'text' },
   ];
-
-  const sheet = _getSheet(DADOS_CADASTRAIS_KEYWORD, spreadSheet)
-  checkEmptySheet(sheet, 'dados cadastrais');
-
-  return _getSheetData(dadosCadastraisModel, sheet);
+  return _getSheetData(dadosCadastraisModel, _getSheet(DADOS_CADASTRAIS_KEYWORD, spreadSheet));
 };
 
 /**

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -685,18 +685,6 @@ describe('parser _getDadosCadastraisData', () => {
     ];
     await testDadosCadastraisData(SIMPLE_DATA_SPREADSHEET_PATH, expectedData);
   });
-
-  it('should throw an error when dados cadastrais sheet is no found', async () => {
-    const spreadsheetBuffer = await getSpreadsheet(MISSING_DADOS_CADASTRAIS_SHEET_SPREADSHEET_PATH);
-    const spreadsheet = convertSpreadsheetToJson(spreadsheetBuffer);
-    try {
-      parser._getDadosCadastraisData(spreadsheet);
-      fail('an error should be thrown');
-    } catch (e) {
-      const { message, code } = errorMessages.SHEET_NOT_FOUND('dados cadastrais');
-      expect(e).toEqual(new APIError(message, 404, code));
-    }
-  });
 });
 
 describe('parser _convertToNameHashTable', () => {


### PR DESCRIPTION
Essa validação existe porque existem planilhas que não possuem a coluna `dados cadastrais` e isso gerava um erro de preenchimento do CSV. Contudo, após as melhorias que fiz no Parser no domingo, essas colunas simplismente ficarão em branco, então a checagem não é mais necessária.